### PR TITLE
Fix balance display showing function code instead of formatted value

### DIFF
--- a/src/lib/server/db/factories/transactions.ts
+++ b/src/lib/server/db/factories/transactions.ts
@@ -4,7 +4,6 @@ import { faker } from "@faker-js/faker";
 import { payeeFactory } from "./payees";
 import type { Payee } from "$lib/schema/payees";
 import { categoryFactory } from "./categories";
-import { rawDateFormatter } from "$lib/helpers/formatters";
 import { CalendarDate } from "@internationalized/date";
 
 export const transactionFactory = async (

--- a/src/routes/accounts/[id]/+page.svelte
+++ b/src/routes/accounts/[id]/+page.svelte
@@ -43,7 +43,7 @@
   <h1 class="mr-5 text-3xl">{account?.name}</h1>
   <span class="text-sm text-muted-foreground">
     <strong>Balance:</strong>
-    {currentAccountState?.balance}
+    {currentAccountState?.balance()}
   </span>
 </div>
 

--- a/tests/integration/views/individual-account-views.test.ts
+++ b/tests/integration/views/individual-account-views.test.ts
@@ -73,6 +73,31 @@ test.describe("Individual Account Views and Displays", () => {
       }
     });
 
+    test("should display balance as valid currency amount", async ({ page }) => {
+      // Find the balance display in the header
+      const balanceSection = page.locator("text=/Balance:/");
+      await expect(balanceSection).toBeVisible();
+      
+      // Extract just the balance amount from the text
+      const balanceText = await balanceSection.textContent();
+      const balanceMatch = balanceText?.match(/\$(-?\d+(?:,\d{3})*\.\d{2})/);
+      
+      // Should find a properly formatted currency amount
+      expect(balanceMatch).not.toBeNull();
+      expect(balanceMatch![1]).toBeTruthy();
+      
+      // Parse the amount to ensure it's a valid number
+      const amountString = balanceMatch![1].replace(/,/g, ''); // Remove commas
+      const amount = parseFloat(amountString);
+      
+      // Should be a valid finite number
+      expect(Number.isFinite(amount)).toBe(true);
+      expect(Number.isNaN(amount)).toBe(false);
+      
+      // Balance should be within reasonable bounds for test data
+      expect(Math.abs(amount)).toBeLessThan(1000000); // Less than $1M
+    });
+
     test("should display account metadata in organized layout", async ({ page }) => {
       // Check for account creation/opened date
       const createdDate = page.locator("[data-testid='account-created']") ||


### PR DESCRIPTION
## Summary
- Fixed Svelte 5 $derived function call in account page template
- Added comprehensive test to ensure balance displays as valid currency
- Removed unused import from transaction factory

## Problem
The account balance was displaying function code instead of the formatted currency value because Svelte 5 `$derived` returns a function that needs to be called.

## Solution
- Changed `{currentAccountState?.balance}` to `{currentAccountState?.balance()}` in the template
- Added test that validates the balance displays as a properly formatted currency amount
- Test checks for valid number parsing and reasonable bounds

## Changes
- **Template Fix**: `src/routes/accounts/[id]/+page.svelte` - Call balance as function
- **Test Coverage**: `tests/integration/views/individual-account-views.test.ts` - Validate currency display
- **Cleanup**: `src/lib/server/db/factories/transactions.ts` - Remove unused import

## Test Plan
- [x] Balance displays as formatted currency (e.g., "$123.45") not function code
- [x] New test validates balance is parseable as valid number
- [x] Test ensures balance is within reasonable bounds
- [x] Existing balance formatting tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)