### PR TITLE
Fix payee filter inconsistency when null (#22)

### DIFF
--- a/src/routes/accounts/[id]/(components)/(facets)/data-table-faceted-filter-category.svelte
+++ b/src/routes/accounts/[id]/(components)/(facets)/data-table-faceted-filter-category.svelte
@@ -28,38 +28,61 @@
       .concat(selectedValues)
   );
   const allCategories = $derived(data.categories);
-
-  const categoryOptions = $derived(
-    new SvelteMap<number, FacetedFilterOption>(
-      categories
-        ?.filter((category: Category) => category.id !== undefined)
-        .map((category: Category) => {
-          return [
-            category.id,
-            {
-              label: category.name || "",
-              value: category.id + "",
-              icon: SquareMousePointer as unknown as Component,
-            },
-          ];
-        })
-    )
+  
+  // Check if there are any transactions with null categories
+  const hasNullCategories = $derived(
+    account.transactions.some((transaction: Transaction) => transaction.categoryId === null)
   );
 
-  const allCategoryOptions = $derived(
-    new SvelteMap<number, FacetedFilterOption>(
-      allCategories?.map((category: Category) => {
-        return [
-          category.id,
-          {
-            label: category.name || "",
-            value: category.id + "",
-            icon: SquareMousePointer as unknown as Component,
-          },
-        ];
-      })
-    )
-  );
+  const categoryOptions = $derived.by(() => {
+    const options = new SvelteMap<number | string, FacetedFilterOption>();
+    
+    // Add "None" option if there are transactions with null categories
+    if (hasNullCategories) {
+      options.set("null", {
+        label: "(None)",
+        value: "null",
+        icon: SquareMousePointer as unknown as Component,
+      });
+    }
+    
+    // Add regular category options
+    categories
+      ?.filter((category: Category) => category.id !== undefined)
+      .forEach((category: Category) => {
+        options.set(category.id, {
+          label: category.name || "",
+          value: category.id + "",
+          icon: SquareMousePointer as unknown as Component,
+        });
+      });
+    
+    return options;
+  });
+
+  const allCategoryOptions = $derived.by(() => {
+    const options = new SvelteMap<number | string, FacetedFilterOption>();
+    
+    // Add "None" option if there are transactions with null categories
+    if (hasNullCategories) {
+      options.set("null", {
+        label: "(None)",
+        value: "null",
+        icon: SquareMousePointer as unknown as Component,
+      });
+    }
+    
+    // Add all category options
+    allCategories?.forEach((category: Category) => {
+      options.set(category.id, {
+        label: category.name || "",
+        value: category.id + "",
+        icon: SquareMousePointer as unknown as Component,
+      });
+    });
+    
+    return options;
+  });
 </script>
 
 <DataTableFacetedFilter

--- a/src/routes/accounts/[id]/(components)/(facets)/data-table-faceted-filter-payee.svelte
+++ b/src/routes/accounts/[id]/(components)/(facets)/data-table-faceted-filter-payee.svelte
@@ -26,38 +26,61 @@
     account.transactions.map((transaction: Transaction) => transaction.payee).concat(selectedValues)
   );
   const allPayees = $derived(data.payees);
-
-  const payeeOptions = $derived(
-    new SvelteMap<number, FacetedFilterOption>(
-      payees
-        ?.filter((payee: Payee) => payee.id !== undefined)
-        .map((payee: Payee) => {
-          return [
-            payee.id,
-            {
-              label: payee.name || "",
-              value: payee.id + "",
-              icon: HandCoins as unknown as Component,
-            },
-          ];
-        })
-    )
+  
+  // Check if there are any transactions with null payees
+  const hasNullPayees = $derived(
+    account.transactions.some((transaction: Transaction) => transaction.payeeId === null)
   );
 
-  const allPayeeOptions = $derived(
-    new SvelteMap<number, FacetedFilterOption>(
-      allPayees?.map((payee: Payee) => {
-        return [
-          payee.id,
-          {
-            label: payee.name || "",
-            value: payee.id + "",
-            icon: HandCoins as unknown as Component,
-          },
-        ];
-      })
-    )
-  );
+  const payeeOptions = $derived.by(() => {
+    const options = new SvelteMap<number | string, FacetedFilterOption>();
+    
+    // Add "None" option if there are transactions with null payees
+    if (hasNullPayees) {
+      options.set("null", {
+        label: "(None)",
+        value: "null",
+        icon: HandCoins as unknown as Component,
+      });
+    }
+    
+    // Add regular payee options
+    payees
+      ?.filter((payee: Payee) => payee.id !== undefined)
+      .forEach((payee: Payee) => {
+        options.set(payee.id, {
+          label: payee.name || "",
+          value: payee.id + "",
+          icon: HandCoins as unknown as Component,
+        });
+      });
+    
+    return options;
+  });
+
+  const allPayeeOptions = $derived.by(() => {
+    const options = new SvelteMap<number | string, FacetedFilterOption>();
+    
+    // Add "None" option if there are transactions with null payees
+    if (hasNullPayees) {
+      options.set("null", {
+        label: "(None)",
+        value: "null",
+        icon: HandCoins as unknown as Component,
+      });
+    }
+    
+    // Add all payee options
+    allPayees?.forEach((payee: Payee) => {
+      options.set(payee.id, {
+        label: payee.name || "",
+        value: payee.id + "",
+        icon: HandCoins as unknown as Component,
+      });
+    });
+    
+    return options;
+  });
 </script>
 
 <DataTableFacetedFilter

--- a/src/routes/accounts/[id]/(data)/filters.svelte.ts
+++ b/src/routes/accounts/[id]/(data)/filters.svelte.ts
@@ -74,7 +74,9 @@ export const filters = {
     addMeta: (meta: any) => void
   ) => {
     type validType = { [key: string]: any };
-    return filterValue.has((row.original as validType)[columnId + "Id"].toString());
+    const entityId = (row.original as validType)[columnId + "Id"];
+    const entityIdStr = entityId === null ? "null" : entityId.toString();
+    return filterValue.has(entityIdStr);
   },
   entityIsNotFilter: (
     row: Row<TransactionsFormat>,
@@ -83,7 +85,9 @@ export const filters = {
     addMeta: (meta: any) => void
   ) => {
     type validType = { [key: string]: any };
-    return !filterValue.has((row.original as validType)[columnId + "Id"].toString());
+    const entityId = (row.original as validType)[columnId + "Id"];
+    const entityIdStr = entityId === null ? "null" : entityId.toString();
+    return !filterValue.has(entityIdStr);
   },
   dateBefore: (
     row: Row<TransactionsFormat>,


### PR DESCRIPTION
## Summary
Resolves inconsistent behavior when filtering transactions with null payee or category values.

## Problem
- Transactions with null `payeeId`/`categoryId` couldn't be filtered properly
- Filter functions used `null.toString()` which created inconsistent string representations
- Filter dropdowns didn't show option for null values
- Users couldn't filter for transactions without payees/categories

## Solution
### Filter Function Fixes
- Added explicit null handling in `entityIsFilter` and `entityIsNotFilter`
- Convert null values to consistent "null" string representation
- Ensure filter matching works for both null and non-null values

### UI Improvements  
- Added "(None)" option in payee and category filter dropdowns
- Show null option only when transactions with null values exist
- Use reactive `$derived.by()` for proper option generation
- Consistent behavior across payee and category filters

## Changes
- **Filter Logic**: Proper null value handling in filter functions
- **Payee Filter**: Shows "(None)" option when null payees exist
- **Category Filter**: Shows "(None)" option when null categories exist
- **Reactivity**: Improved option generation with `$derived.by()`

## Test Plan
- [x] Filter for transactions without payees shows "(None)" option
- [x] Filter for transactions without categories shows "(None)" option  
- [x] Selecting "(None)" filters correctly
- [x] Normal payee/category filtering still works
- [x] Filter options only show when null values exist in data

Fixes #22