### PR TITLE
Change status filter icon for better visual clarity (#27)

### DIFF
--- a/src/routes/accounts/[id]/(data)/columns.svelte.ts
+++ b/src/routes/accounts/[id]/(data)/columns.svelte.ts
@@ -23,7 +23,7 @@ import DataTableFacetedFilterDate from "../(components)/(facets)/data-table-face
 import CalendarDays from "@lucide/svelte/icons/calendar-days";
 import HandCoins from "@lucide/svelte/icons/hand-coins";
 import SquareMousePointer from "@lucide/svelte/icons/square-mouse-pointer";
-import CircleCheckBig from "@lucide/svelte/icons/circle-check-big";
+import SquareCheck from "@lucide/svelte/icons/square-check";
 import { ExpandToggle } from "$lib/components/ui/expand-toggle";
 import { currencyFormatter } from "$lib/utils/formatters";
 import type { Component } from "svelte";
@@ -377,7 +377,7 @@ export const columns = (
         facetedFilter: (column: Column<TransactionsFormat, unknown>, value: unknown[]) => {
           return {
             name: "Status",
-            icon: CircleCheckBig,
+            icon: SquareCheck,
             column,
             value,
             component: () => {


### PR DESCRIPTION
## Summary
Updates the status filter icon to better align with the actual status cell representation and improve visual consistency.

## Changes
- **Icon Change**: Replace `CircleCheckBig` with `SquareCheck` for status filter
- **Visual Consistency**: Align filter icon with status cell icons
- **Semantic Alignment**: Better represents the actual status values

## Rationale
The status cell component uses:
- `SquareCheck` for "cleared" status  
- `Square` for "pending" status
- `CalendarClock` for "scheduled" status

Using `SquareCheck` in the filter provides better visual consistency with the actual status representations, making it immediately clear what the filter controls.

## Visual Impact
- Filter icon now matches the primary status icon (cleared transactions)
- More intuitive connection between filter and filtered content
- Consistent iconography across status-related components

## Test Plan
- [x] Status filter displays new SquareCheck icon
- [x] Filter functionality remains unchanged
- [x] Visual consistency with status cell improved
- [x] Icon imports and usage are correct

Fixes #27